### PR TITLE
パスワードポリシーを統一する

### DIFF
--- a/files/sns/app/controllers/password_reset_controller.rb
+++ b/files/sns/app/controllers/password_reset_controller.rb
@@ -12,6 +12,8 @@ class PasswordResetController < ApplicationController
 
   def update
     begin
+      render json: {errors: ['Passを入力してください']}, status: :bad_request and return if params[:pass].empty?
+
       payload = decode_reset_token(params[:reset_token])
       user = User.find payload[:id]
       user.update(pass: Digest::MD5.hexdigest(params[:pass]))


### PR DESCRIPTION
## 背景
パスワードポリシーが新規登録時とパスワードリセット時で違う(意図しない挙動?)
- 新規登録
→ パスワードが1文字以上(空は許されない)

- パスワードリセット
→ パスワードが空でも可能

## 変更点
パスワードリセット時に、パスワードが空だった場合 `Passを入力してください` というエラーメッセージが表示されるようにした

**実際の表示**
![image](https://user-images.githubusercontent.com/22651063/82407874-466c3780-9aa5-11ea-8011-f5fc3d15bb05.png)

## 補足
意図している脆弱性を潰さないように、 model側は触らずcontrollerのみ修正しました